### PR TITLE
Consider all valid protocol characters

### DIFF
--- a/src/miuri.coffee
+++ b/src/miuri.coffee
@@ -7,7 +7,7 @@
 ###
 regex = ///
 
-  ^(?:(\w+)://)?     # protocol
+  ^(?:(\w+|[-+\.]+)://)?     # protocol
   (?:
     (\w+)            # username
     (?::(\w+))?      # password


### PR DESCRIPTION
Protocols may include more than just \w - Hyphens, digits, dashes and plus are allowed.
(See [spec](http://www.ietf.org/rfc/rfc1738.txt), Section 2.1)

Most of those aren't common, but I stumbled upon the missing dash when working with a chrome-extension:// URI.
