### PR TITLE
Fix special character detection in protocols

### DIFF
--- a/src/miuri.coffee
+++ b/src/miuri.coffee
@@ -7,7 +7,7 @@
 ###
 regex = ///
 
-  ^(?:(\w+|[-+\.]+)://)?     # protocol
+  ^(?:([A-Za-z-+\.]+)://)?     # protocol
   (?:
     (\w+)            # username
     (?::(\w+))?      # password


### PR DESCRIPTION
My previous fix made chrome-extension to be divided into several parts, and then screw up the host part later on.
So now it uses a single character class, and it works flawlessly.

Had to change \w into a-zA-Z (more precisely what the spec allows anyway, without unicode chars) because Webstorm complaines about having character ranges inside character classes.
